### PR TITLE
New stat parse

### DIFF
--- a/pairsamtools/pairsam_stats.py
+++ b/pairsamtools/pairsam_stats.py
@@ -369,7 +369,7 @@ class StatObject(Mapping):
                         dist_bin_left = bin_range.strip('+') if bin_range.endswith('+') \
                                     else bin_range.split('-')[0]
                         # get the index of that bin:
-                        bin_idx = np.searchsorted(cls._dist_bins, int(dist_bin_left), 'right') - 1
+                        bin_idx = np.searchsorted(stat_from_file._dist_bins, int(dist_bin_left), 'right') - 1
                         # store corresponding value:
                         stat_from_file._stat[key][dirs][bin_idx] = int(fields[1])
                     else:

--- a/pairsamtools/pairsam_stats.py
+++ b/pairsamtools/pairsam_stats.py
@@ -66,104 +66,35 @@ def stats_py(input_path, output, merge, **kwargs):
 
 
     header, body_stream = _headerops.get_header(instream)
-    
-    stats = OrderedDict()
-    stats['total'] = 0
-    stats['total_unmapped'] = 0
-    stats['total_single_sided_mapped'] = 1
-    stats['total_mapped'] = 0
-    stats['cis'] = 0
-    stats['trans'] = 0
-    stats['pair_types'] = {}
 
-    stats['cis_1kb+'] = 0
-    stats['cis_2kb+'] = 0
-    stats['cis_10kb+'] = 0
-    stats['cis_20kb+'] = 0
 
-    stats['chrom_freq'] = OrderedDict()
-    min_log10_dist = 0
-    max_log10_dist = 9
-    bin_log10_spacing = 0.25
-    dist_bins = (np.r_[0,
-        np.round(10**np.arange(min_log10_dist, max_log10_dist+0.001, bin_log10_spacing))
-        .astype(np.int)]
-    )
-
-    stats['dist_freq'] = OrderedDict([
-        ('+-', np.zeros(len(dist_bins), dtype=np.int)),
-        ('-+', np.zeros(len(dist_bins), dtype=np.int)),
-        ('--', np.zeros(len(dist_bins), dtype=np.int)),
-        ('++', np.zeros(len(dist_bins), dtype=np.int)),
-        ])
+    # new stats class stuff would come here ...
+    stats = StatObject()
 
     # Collecting statistics
     for line in body_stream:
         cols = line.rstrip().split(_pairsam_format.PAIRSAM_SEP)
-        chrom1, pos1, strand1 = (
-                cols[_pairsam_format.COL_C1], 
-                int(cols[_pairsam_format.COL_P1]),
-                cols[_pairsam_format.COL_S1])
-        chrom2, pos2, strand2 = (
-                cols[_pairsam_format.COL_C2], 
-                int(cols[_pairsam_format.COL_P2]),
-                cols[_pairsam_format.COL_S2])
+
+        algn1 = {
+            'chrom': cols[_pairsam_format.COL_C1],
+            'pos': int(cols[_pairsam_format.COL_P1]),
+            'strand': cols[_pairsam_format.COL_S1] }
+
+        algn2 = {
+            'chrom': cols[_pairsam_format.COL_C2],
+            'pos': int(cols[_pairsam_format.COL_P2]),
+            'strand': cols[_pairsam_format.COL_S2] }
 
         pair_type = cols[_pairsam_format.COL_PTYPE]
-        stats['total'] += 1
-        stats['pair_types'][pair_type] = stats['pair_types'].get(pair_type,0) +1
-        if chrom1 == '!' and chrom2 == '!':
-            stats['total_unmapped'] += 1
-        elif chrom1 != '!' and chrom2 != '!':
-            stats['chrom_freq'][(chrom1, chrom2)] = (
-                stats['chrom_freq'].get((chrom1, chrom2),0) + 1)
-            stats['total_mapped'] += 1
-
-            if chrom1 == chrom2:
-                stats['cis'] += 1
-                dist = np.abs(pos2-pos1)
-                bin_idx = np.searchsorted(dist_bins, dist, 'right') -1
-                stats['dist_freq'][strand1+strand2][bin_idx] += 1
-                if dist >= 1000:
-                    stats['cis_1kb+'] += 1
-                if dist >= 2000:
-                    stats['cis_2kb+'] += 1
-                if dist >= 10000:
-                    stats['cis_10kb+'] += 1
-                if dist >= 20000:
-                    stats['cis_20kb+'] += 1
-
-            else:
-                stats['trans'] += 1
-        else:
-            stats['total_single_sided_mapped'] += 1
+        #
+        #
+        stats.update(algn1, algn2, pair_type)
 
 
-    # Storing statistics
-    for k,v in stats.items():
-        if isinstance(v, int):
-            outstream.write('{}\t{}\n'.format(k,v))
-        else:
-            if k == 'dist_freq':
-                for i in range(len(dist_bins)):
-                    for dirs, freqs in v.items():
-                        if i != len(dist_bins) - 1:
-                            outstream.write('{}/{}-{}/{}\t{}\n'.format(
-                                k, dist_bins[i], dist_bins[i+1], dirs, freqs[i])
-                                )
-                        else:
-                            outstream.write('{}/{}+/{}\t{}\n'.format(
-                                k, dist_bins[i], dirs, freqs[i]))
 
-            if k == 'pair_types':
-                for pair_type, freq in v.items():
-                    outstream.write('{}/{}\t{}\n'.format(
-                        k, pair_type, freq))
+    # save statistics to file ...
+    stats.save(outstream)
 
-            if k == 'chrom_freq':
-                for (chrom1, chrom2), freq in v.items():
-                    outstream.write('{}/{}/{}\t{}\n'.format(
-                        k, chrom1, chrom2, freq))
 
 
     if instream != sys.stdin:
@@ -172,53 +103,198 @@ def stats_py(input_path, output, merge, **kwargs):
         outstream.close()
 
 
+
+
+
+
 def do_merge(output, files_to_merge, **kwargs):
 
     # Parse all stats files.
     stats = []
     for stat_file in files_to_merge:
         f = _fileio.auto_open(stat_file, mode='r', 
-                              nproc=kwargs.get('nproc_in'),
-                              command=kwargs.get('cmd_in', None)) 
-        stat = OrderedDict()
-        for l in f:
-            fields = l.strip().split('\t') 
-            if len(fields) == 0:
-                continue
-            if len(fields) != 2:
-                raise _fileio.ParseError(
-                    '{} is not a valid stats file'.format(stat_file))
-            stat[fields[0]] = int(fields[1])
-
+                      nproc=kwargs.get('nproc_in'),
+                      command=kwargs.get('cmd_in', None)) 
+        stat = StatObject(file_handle = f)
         stats.append(stat)
         f.close()
 
-    # Find a set of all possible keys. First, print overlapping keys, 
-    # preserving the order. Then, add unique keys from each of the stats tables.
-    out_keys = [
-        k for k in stats[0]
-        if all(k in stat for stat in stats)]
-
-    for stat in stats:
-        out_keys += [
-            k for k in stat
-            if k not in out_keys]
-
-    # Sum all stats.
-    out_stats = OrderedDict()
-    for k in out_keys:
-        out_stats[k] = sum(stat.get(k, 0) for stat in stats)
+    # combine stats from several files (files_to_merge):
+    out_stat = sum(stats)
 
 
     # Save merged stats.
     outstream = _fileio.auto_open(output, mode='w', 
                                   nproc=kwargs.get('nproc_out'),
                                   command=kwargs.get('cmd_out', None))
-    for k,v in out_stats.items():
-        outstream.write('{}\t{}\n'.format(k,v))
+
+    # save statistics to file ...
+    out_stat.save(outstream)
         
     if outstream != sys.stdout:
         outstream.close()
 
+
+class StatObject(object):
+    """docstring for StatObject:
+    A class that defines a simple container
+    for sequencing statistics and simple operations
+    for the class (accumulation, merge and output)."""
+    def __init__(self, file_handle = None, stat_dict = None):
+
+        if stat_dict:
+            self.stat = stat_dict
+        else:
+            # initialize empty stat dictironary:
+            self.stat = OrderedDict()
+            # fill it from file or establish an empty one:
+            if file_handle:
+                # fill in from file_handle:
+                for l in file_handle:
+                    fields = l.strip().split('\t') 
+                    if len(fields) == 0:
+                        continue
+                    if len(fields) != 2:
+                        raise _fileio.ParseError(
+                            '{} is not a valid stats file'.format(file_handle.name))
+                    self.stat[fields[0]] = int(fields[1])
+            else:
+                # some more variables used for initialization:
+                self.min_log10_dist = 0
+                self.max_log10_dist = 9
+                self.bin_log10_spacing = 0.25
+                self.dist_bins = (np.r_[0,
+                    np.round(10**np.arange(self.min_log10_dist, self.max_log10_dist+0.001, self.bin_log10_spacing))
+                    .astype(np.int)]
+                )
+
+                # establish structure of an empty stat:
+                self.stat['total'] = 0
+                self.stat['total_unmapped'] = 0
+                self.stat['total_single_sided_mapped'] = 1
+                self.stat['total_mapped'] = 0
+                self.stat['cis'] = 0
+                self.stat['trans'] = 0
+                self.stat['pair_types'] = {}
+
+                self.stat['cis_1kb+'] = 0
+                self.stat['cis_2kb+'] = 0
+                self.stat['cis_10kb+'] = 0
+                self.stat['cis_20kb+'] = 0
+
+                self.stat['chrom_freq'] = OrderedDict()
+
+                self.stat['dist_freq'] = OrderedDict([
+                    ('+-', np.zeros(len(self.dist_bins), dtype=np.int)),
+                    ('-+', np.zeros(len(self.dist_bins), dtype=np.int)),
+                    ('--', np.zeros(len(self.dist_bins), dtype=np.int)),
+                    ('++', np.zeros(len(self.dist_bins), dtype=np.int)),
+                    ])
+
+
+    def update(self, algn1, algn2, pair_type):
+        # extract chrom, position and strand from each of the alignmentns:
+        chrom1, pos1, strand1 = ( algn1['chrom'], algn1['pos'], algn1['strand'] )
+        chrom2, pos2, strand2 = ( algn2['chrom'], algn2['pos'], algn2['strand'] )
+
+        self.stat['total'] += 1
+        self.stat['pair_types'][pair_type] = self.stat['pair_types'].get(pair_type,0) + 1
+        if chrom1 == '!' and chrom2 == '!':
+            self.stat['total_unmapped'] += 1
+        elif chrom1 != '!' and chrom2 != '!':
+            self.stat['chrom_freq'][(chrom1, chrom2)] = (
+                self.stat['chrom_freq'].get((chrom1, chrom2),0) + 1)
+            self.stat['total_mapped'] += 1
+
+            if chrom1 == chrom2:
+                self.stat['cis'] += 1
+                dist = np.abs(pos2-pos1)
+                bin_idx = np.searchsorted(self.dist_bins, dist, 'right') - 1
+                self.stat['dist_freq'][strand1+strand2][bin_idx] += 1
+                if dist >= 1000:
+                    self.stat['cis_1kb+'] += 1
+                if dist >= 2000:
+                    self.stat['cis_2kb+'] += 1
+                if dist >= 10000:
+                    self.stat['cis_10kb+'] += 1
+                if dist >= 20000:
+                    self.stat['cis_20kb+'] += 1
+
+            else:
+                self.stat['trans'] += 1
+        else:
+            self.stat['total_single_sided_mapped'] += 1
+
+
+    def __add__(self, other):
+        stats = [self.stat, other.stat]
+
+        # Find a set of all possible keys. First, print overlapping keys, 
+        # preserving the order. Then, add unique keys from each of the stats tables.
+        out_keys = [
+            k for k in stats[0]
+            if all(k in stat for stat in stats)]
+
+        for stat in stats:
+            out_keys += [
+                k for k in stat
+                if k not in out_keys]
+
+        # Sum all stats.
+        out_stats = OrderedDict()
+        for k in out_keys:
+            out_stats[k] = sum(stat.get(k, 0) for stat in stats)
+
+        # return the result of a merger:
+        return StatObject(stat_dict = out_stats)
+
+
+    # we need this to be able to sum(list_of_StatObjects)
+    def __radd__(self, other):
+        if other == 0:
+            return self
+        else:
+            return self.__add__(other)
+
+
+    def save(self, outstream):
+        # Storing statistics
+        for k,v in self.stat.items():
+            # this should work for the stat initialized with the file:
+            if isinstance(v, int):
+                outstream.write('{}\t{}\n'.format(k,v))
+            # this is used to store newly initialized stat-object:
+            else:
+                if k == 'dist_freq':
+                    for i in range(len(self.dist_bins)):
+                        for dirs, freqs in v.items():
+                            if i != len(self.dist_bins) - 1:
+                                outstream.write('{}/{}-{}/{}\t{}\n'.format(
+                                    k, self.dist_bins[i], self.dist_bins[i+1], dirs, freqs[i])
+                                    )
+                            else:
+                                outstream.write('{}/{}+/{}\t{}\n'.format(
+                                    k, self.dist_bins[i], dirs, freqs[i]))
+
+                if k == 'pair_types':
+                    for pair_type, freq in v.items():
+                        outstream.write('{}/{}\t{}\n'.format(
+                            k, pair_type, freq))
+
+                if k == 'chrom_freq':
+                    for (chrom1, chrom2), freq in v.items():
+                        outstream.write('{}/{}/{}\t{}\n'.format(
+                            k, chrom1, chrom2, freq))
+
+
 if __name__ == '__main__':
     stats()
+
+
+
+
+
+
+
+
+

--- a/pairsamtools/pairsam_stats.py
+++ b/pairsamtools/pairsam_stats.py
@@ -171,7 +171,7 @@ class StatObject(object):
                 # establish structure of an empty stat:
                 self.stat['total'] = 0
                 self.stat['total_unmapped'] = 0
-                self.stat['total_single_sided_mapped'] = 1
+                self.stat['total_single_sided_mapped'] = 0
                 self.stat['total_mapped'] = 0
                 self.stat['cis'] = 0
                 self.stat['trans'] = 0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -31,7 +31,7 @@ def test_mock_pairsam():
     print(stats)
 
     assert stats['total'] == 8
-    assert stats['total_single_sided_mapped'] == 4
+    assert stats['total_single_sided_mapped'] == 3
     assert stats['total_mapped'] == 5
     assert stats['cis'] == 3
     assert stats['trans'] == 2


### PR DESCRIPTION
thoroughly tested commit that introduces `stats` to `parse`, using a `class StatObject`(name is bad, I agree). Such an implementation does not degrade the performance in a noticeable way, and allows us to (1) simplify the code for `pairsamtools stats` themselves (2) introduce `stats` gathering into `pairsamtools parse` in a least obtrusive way(not very obtrusive, let's put it this way).

I've tested the reimplemented `stats` (including merge) on test data and in a big data scenario, where I merged 13 chunks of `.stats` files into one. Stats match perfectly with previous implementation, except for the `total_single_sided_mapped`, which was initialized with 1 instead of 0 for some reason. I fixed it to`stats['total_single_sided_mapped'] = 0`.

Let me know if an implementation using a `class` is not desirable, and please feel free to rename `class methods`, which I dislike greatly, but cannot come up with anything better. Complementary distiller PR is coming right away.