### PR TITLE
added dedup category to stats

### DIFF
--- a/pairsamtools/pairsam_dedup.py
+++ b/pairsamtools/pairsam_dedup.py
@@ -216,9 +216,9 @@ def dedup_py(
         stat_f = _fileio.auto_open(output_stats, mode='a',
                                    nproc=kwargs.get('nproc_out'),
                                    command=kwargs.get('cmd_out', None))
-        stat_f.write('{}\t{}\n'.format('n_unmapped', n_unmapped))
-        stat_f.write('{}\t{}\n'.format('n_dups', n_dups))
-        stat_f.write('{}\t{}\n'.format('n_nodups', n_nodups))
+        stat_f.write('{}\t{}\n'.format('dedup/n_unmapped', n_unmapped))
+        stat_f.write('{}\t{}\n'.format('dedup/n_dups', n_dups))
+        stat_f.write('{}\t{}\n'.format('dedup/n_nodups', n_nodups))
         stat_f.close()
 
     if instream != sys.stdin:


### PR DESCRIPTION
added `dedup` category to the `PairCounter` class (aka `stats`), it is treated mostly the same way as the `pair_types`, since they are both simple `dicts` one level down from the root of the main `_stats` dictionary.

`pairsamtools_dedup.py` is not using the `PairCounter` class, however, and instead simply prints several lines of dedup related statistics to the corresponding `.dedup.stats` file. Merging such files with proper `.stats` files works just fine, though: because `PairCounter.from_file` and `PairCounter.__add__` methods are written such that they can accommodate for incomplete `.stats` files/objects.

This commit is tested as part of distiller test sample and works like a charm.

Hopefully this would complete our series of stats-related updates.