### PR TITLE
bug fix: split stripped lines in dedup

### DIFF
--- a/pairsamtools/pairsam_dedup.py
+++ b/pairsamtools/pairsam_dedup.py
@@ -296,12 +296,16 @@ def streaming_dedup(
         if line:
             if not stripline: 
                 warnings.warn("Empty line detected not at the end of the file")
-                continue    
+                continue
 
-            cols = line.split(sep)
+            # split the 'stripline', insted of 'line'
+            # otherwise newline symbol might persists
+            # along with the pairtype, e.g. "UU\n" vs "UU", 
+            # and cause havoc downstream, e.g. in `stats`.
+            cols = stripline.split(sep)
             if len(cols) <= maxind:
                 raise ValueError(
-                    "Error parsing line {}: ".format(line)
+                    "Error parsing line {}: ".format(stripline)
                     + " expected {} columns, got {}".format(maxind, len(cols)))
                 
             if ((cols[c1ind] == unmapped_chrom)


### PR DESCRIPTION
Tiny but important bug fix:

we were splitting a raw line instead of stripped one in dedup.
This way, when one drops sams, etc. from `pairsam` file, the `pairtype` column becomes the last one in each row, and newline symbol `\n` becomes part of that `pairtype`-value, e.g. `UU\n` instead of `UU`.

This was causing downstream troubles, at least in `stats`, when we were trying to merge several `stat` files with entries like that:
```
...
pair_types/MM
        10609396
pair_types/NM
        7163577
pair_types/NN
        4432250
...
```

Again , we would excpect this to look the following way:
```
...
pair_types/MM        10609396
pair_types/NM        7163577
pair_types/NN        4432250
...
```

So, just replace `line` to `splitline`, at least in place where we are splitting that line. That's it!
